### PR TITLE
ingress pathways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is a crummy changelog. Sue me.
 
 * ingress handles both `web` and `hec`
 * still lots of work to do on this
-* local example ingress now uses https
+* local example ingress now forwards http (8080) and https (4443)
 
 ## [0.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is a crummy changelog. Sue me.
 
+## [0.10.0]
+
+* ingress handles both `web` and `hec`
+* still lots of work to do on this
+
 ## [0.9.0]
 
 * move `web.service.annotations` under `service.annoations`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a crummy changelog. Sue me.
 
 * ingress handles both `web` and `hec`
 * still lots of work to do on this
+* local example ingress now uses https
 
 ## [0.9.0]
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,7 @@ tasks:
 
   forward:
     cmds:
-      - kubectl -n nginx-ingress port-forward svc/nginx-ingress-controller 8000:8000 8088:8088
+      - kubectl -n nginx-ingress port-forward svc/nginx-ingress-controller 8080:80
 
   sync:
     dir: ci

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,7 @@ tasks:
 
   forward:
     cmds:
-      - kubectl -n nginx-ingress port-forward svc/nginx-ingress-controller 8080:80
+      - kubectl -n nginx-ingress port-forward svc/nginx-ingress-controller 8080:80 4443:443
 
   sync:
     dir: ci

--- a/charts/splunk/Chart.yaml
+++ b/charts/splunk/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 7.0.3
 description: splunk, but intended for use as an HTTP endpoint collector (HEC)
 name: splunk
-version: 0.9.0
+version: 0.10.0

--- a/charts/splunk/templates/ingress.yaml
+++ b/charts/splunk/templates/ingress.yaml
@@ -34,16 +34,6 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.httpBindPort }}
-          ## TODO
-          ## HEC pathways
-          ## better way to configure these...?
-          ## Still don't fully understand why splunk has them under different port routes
-          ## https://docs.splunk.com/Documentation/SplunkCloud/7.2.7/Data/Senddata
-          ##
-          ## Generally we assume Ingress is handling TLS termination, so TLS should
-          ## be disabled on HEC... Or I guess you could do TLS passthrough if you
-          ## wanted to configure the certs on the splunk server directly
-          ## you do you, you know?
           - path: /services/collector
             backend:
               serviceName: {{ $fullName }}

--- a/charts/splunk/templates/ingress.yaml
+++ b/charts/splunk/templates/ingress.yaml
@@ -34,17 +34,11 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.httpBindPort }}
-          - path: /services/collector
+        {{- range $.Values.ingress.hec.paths }}
+          - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.hecBindPort }}
-          - path: /services/collector/event
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $.Values.service.hecBindPort }}
-          - path: /services/collector/raw
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $.Values.service.hecBindPort }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/splunk/templates/ingress.yaml
+++ b/charts/splunk/templates/ingress.yaml
@@ -34,6 +34,9 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.httpBindPort }}
+        ## TODO perhaps make whether or not the HEC is active configurable?
+        ## that way maybe we could separate them and be able to turn off
+        ## the web UI
         {{- range $.Values.ingress.hec.paths }}
           - path: {{ . }}
             backend:

--- a/charts/splunk/templates/ingress.yaml
+++ b/charts/splunk/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "splunk.fullname" . -}}
-{{- $svcPort := .Values.service.httpBindPort -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -28,14 +27,34 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ . | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          - path: /
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-        {{- end }}
+              servicePort: {{ $.Values.service.httpBindPort }}
+          ## TODO
+          ## HEC pathways
+          ## better way to configure these...?
+          ## Still don't fully understand why splunk has them under different port routes
+          ## https://docs.splunk.com/Documentation/SplunkCloud/7.2.7/Data/Senddata
+          ##
+          ## Generally we assume Ingress is handling TLS termination, so TLS should
+          ## be disabled on HEC... Or I guess you could do TLS passthrough if you
+          ## wanted to configure the certs on the splunk server directly
+          ## you do you, you know?
+          - path: /services/collector
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $.Values.service.hecBindPort }}
+          - path: /services/collector/event
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $.Values.service.hecBindPort }}
+          - path: /services/collector/raw
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $.Values.service.hecBindPort }}
   {{- end }}
 {{- end }}

--- a/charts/splunk/values.yaml
+++ b/charts/splunk/values.yaml
@@ -47,13 +47,12 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
-      paths: []
+    - splunk.127.0.0.1.xip.io
 
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
-  #      - chart-example.local
+  #      - splunk.127.0.0.1.xip.io
 
 resources: {}
   # limits:

--- a/charts/splunk/values.yaml
+++ b/charts/splunk/values.yaml
@@ -41,6 +41,28 @@ service:
   ##
   annotations: {}
 
+##
+## When using an ingress, you don't specify the port
+## that's used for HEC. It's assumed :443 is used for both
+## the UI and HEC. These are the paths under any "host" value
+## that will route to the HEC.
+##
+## For example, given "ingress.hosts: [splunk.example.com]",
+## then the UI will be at https://splunk.example.com, and the
+## HEC endpoints will be at https://splunk.example.com/services/collector/...
+##
+## If you *aren't* using an ingress and are using a service: LoadBalancer,
+## then you still have to specify the port,
+## e.g. "https://loadbalanacerip:8088/services/..."
+##
+## It's *sort of* like the setup used by Splunk Cloud
+## https://docs.splunk.com/Documentation/SplunkCloud/7.2.7/Data/Senddata
+##
+## Generally we assume ingress is handling TLS termination, so TLS should
+## be disabled on the HEC, etc... Or I guess you could have the ingress do
+## TLS passthrough if you wanted to configure certificates on the
+## Splunk server directly. You do you.
+##
 ingress:
   enabled: false
   annotations: {}
@@ -53,6 +75,17 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - splunk.127.0.0.1.xip.io
+
+  ##
+  ## There's probably no reason to change these
+  ## See also:
+  ## https://docs.splunk.com/Documentation/Splunk/7.3.2/Data/HECRESTendpoints
+  ##
+  hec:
+    paths:
+    - /services/collector
+    - /services/collector/event
+    - /services/collector/raw
 
 resources: {}
   # limits:

--- a/charts/splunk/values.yaml
+++ b/charts/splunk/values.yaml
@@ -77,9 +77,11 @@ ingress:
   #      - splunk.127.0.0.1.xip.io
 
   ##
-  ## There's probably no reason to change these
-  ## See also:
   ## https://docs.splunk.com/Documentation/Splunk/7.3.2/Data/HECRESTendpoints
+  ##
+  ## There's probably no reason to change these, but if you want
+  ## to add more paths, in your values.yaml you'll likely need to include
+  ## the paths defined in this default
   ##
   hec:
     paths:

--- a/ci/config/nginx-ingress/values.yml
+++ b/ci/config/nginx-ingress/values.yml
@@ -5,11 +5,11 @@ controller:
     type: NodePort
     ## deactivate to save some ports
     enableHttp: true
-    enableHttps: false
+    enableHttps: true
 
 defaultBackend:
   enabled: false
 
 tcp:
   9997: "splunk/splunk:9997"
-  # 5514: "splunk/splunk:5514"
+  5514: "splunk/splunk:5514"

--- a/ci/config/nginx-ingress/values.yml
+++ b/ci/config/nginx-ingress/values.yml
@@ -4,14 +4,12 @@ controller:
   service:
     type: NodePort
     ## deactivate to save some ports
-    enableHttp: false
+    enableHttp: true
     enableHttps: false
 
 defaultBackend:
   enabled: false
 
 tcp:
-  8000: "splunk/splunk:8000"
-  # 9997: "splunk/splunk:9997"
-  8088: "splunk/splunk:8088"
+  9997: "splunk/splunk:9997"
   # 5514: "splunk/splunk:5514"

--- a/ci/config/splunk/values.yml
+++ b/ci/config/splunk/values.yml
@@ -7,9 +7,10 @@ adminPassword: e9f630105cd740e3b0d81439ef821973 # uuidgen
 ingress:
   enabled: true
   hosts:
-    - host: splunk.127.0.0.1.xip.io
-      paths:
-        - /
+    - splunk.127.0.0.1.xip.io
+  tls:
+    - hosts:
+        - splunk.127.0.0.1.xip.io
 
 conf:
   inputs.conf: |


### PR DESCRIPTION
closes https://github.com/aegershman/splunk-helm-chart/issues/29

probably best to turn off ssl on the hec if using ingress because ingress is handling tls termination